### PR TITLE
Make sure Webpack builds synchronously

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var gaze = require('gaze');
+var glob = require('glob');
 var sprity = require('sprity');
 
 function SprityWebpackPlugin(options) {
@@ -8,6 +10,27 @@ SprityWebpackPlugin.prototype.apply = function(compiler) {
   compiler.plugin('run', function (compiler, callback) {
     sprity.create(this.options, function() {
       callback();
+    });
+  }.bind(this));
+
+  var watchStarted = false;
+  compiler.plugin('watch-run', function (watching, watchRunCallback) {
+    if (watchStarted) {
+      return watchRunCallback();
+    }
+    watchStarted = true;
+    gaze(
+      this.options.src,
+      {},
+      function (err, gaze) {
+        err && fThrow(err);
+        gaze.on('all', function () {
+          sprity.create(this.options, function() {});
+        }.bind(this));
+      }.bind(this)
+    );
+    return sprity.create(this.options, function() {
+      watchRunCallback();
     });
   }.bind(this));
 };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,11 @@ function SprityWebpackPlugin(options) {
 }
 
 SprityWebpackPlugin.prototype.apply = function(compiler) {
-  sprity.create(this.options, function() {});
+  compiler.plugin('run', function (compiler, callback) {
+    sprity.create(this.options, function() {
+      callback();
+    });
+  }.bind(this));
 };
 
 module.exports = SprityWebpackPlugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sprity-webpack-plugin",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Build sprite images and css sheets on the fly with sprity while running webpack.",
   "main": "index.js",
   "scripts": {
@@ -25,6 +25,8 @@
   },
   "homepage": "https://github.com/crossjs/sprity-webpack-plugin#readme",
   "dependencies": {
+    "gaze": "^1.0.0",
+    "glob": "^7.0.3",
     "sprity": "^1.0.8"
   }
 }


### PR DESCRIPTION
I've been having trouble using this plugin and using it together in my build system. I am generating the sprites with sprity and outputting SASS and then importing the SASS back into my build system. This caused a race condition, where the SASS would try to compile, when the sprite SASS would not be generated yet, throwing an error.

I made a patch where I make sure sprity generates the files I need, before it does any bundling. Also I added support for watching. I looked at the spritesmith implementation and used that as a base. The extra watch functionality unfortunately does mean a dependency on gaze and glob.

Let me know what you think!